### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#读取通讯录数据并进行美化 按照名字生成各种颜色的头像 和索引条的创建
+# 读取通讯录数据并进行美化 按照名字生成各种颜色的头像 和索引条的创建
 里面封装有读取通讯录和字母排序，头像生成 等
  增加了打电话的功能,以及头像名称长度大于2只显示后俩个,当俩个时直接显示俩个.
   <img src="https://raw.githubusercontent.com/hackxhj/BeautyAddressBook/master/ok.png" alt="show" title="show">


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
